### PR TITLE
add abs.yaml for sf

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+aggregate_check: false
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40


### PR DESCRIPTION
Adding channel info in abs yaml to upload package to Snowflake channel.
This should have been done in [PR#1](https://github.com/AnacondaRecipes/pymc-marketing-feedstock/pull/1) but was neglected.